### PR TITLE
Use rest client and ditch yam gem

### DIFF
--- a/lib/lolcommits/yammer/version.rb
+++ b/lib/lolcommits/yammer/version.rb
@@ -1,5 +1,5 @@
 module Lolcommits
   module Yammer
-    VERSION = "0.0.2".freeze
+    VERSION = "0.0.3".freeze
   end
 end

--- a/lolcommits-yammer.gemspec
+++ b/lolcommits-yammer.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.0.0"
 
-  spec.add_runtime_dependency "yam"
+  spec.add_runtime_dependency "rest-client"
   spec.add_runtime_dependency "webrick"
 
   spec.add_development_dependency "lolcommits", ">= 0.9.5"

--- a/test/lolcommits/plugin/yammer_test.rb
+++ b/test/lolcommits/plugin/yammer_test.rb
@@ -71,12 +71,11 @@ describe Lolcommits::Plugin::Yammer do
 
           output.must_equal "Posting to Yammer ... done!\n"
           assert_requested :post, create_message_api_url, times: 1, headers: {
-            'Accept'          => 'application/json',
-            'Accept-Encoding' => 'gzip, deflate',
-            'Authorization'   => 'Bearer oV4MuwnNKql3ebJMAYZRaD',
-            'Content-Type'    => /multipart\/form-data/,
-            'User-Agent'      => /Yammer Ruby Gem/
-          }
+            'Authorization' => 'Bearer oV4MuwnNKql3ebJMAYZRaD',
+            'Content-Type'  => /multipart\/form-data/
+          } do |req|
+            req.body.must_match(/Content-Disposition: form-data;.+name="attachment1"; filename="main_image.jpg.+"/)
+          end
         end
       end
 
@@ -88,7 +87,7 @@ describe Lolcommits::Plugin::Yammer do
           output.split("\n").must_equal(
             [
               "Posting to Yammer ... failed :(",
-              "Yammer error: Invalid response code (503)",
+              "Yammer error: 503 Service Unavailable",
               "Try a lolcommits capture with `--debug` and check for errors: `lolcommits -c --debug`"
             ]
           )
@@ -137,11 +136,11 @@ describe Lolcommits::Plugin::Yammer do
           yammer_oauth_code  = "yam-oauth-code"
           klass              = plugin.class
 
-          stub_request(:post, klass::YAMMER_ACCESS_TOKEN_URL).with(
+          stub_request(:post, klass::ACCESS_TOKEN_URL).with(
             body: {
-              "client_id"     => klass::YAMMER_CLIENT_ID,
-              "client_secret" => klass::YAMMER_CLIENT_SECRET,
-              "code"          => yammer_oauth_code
+              "client_id"     => klass::OAUTH_CLIENT_ID,
+              "client_secret" => klass::OAUTH_CLIENT_SECRET,
+              "code"          => [yammer_oauth_code]
             }
           ).to_return(
             status: 200,
@@ -170,7 +169,7 @@ describe Lolcommits::Plugin::Yammer do
   private
 
   def create_message_api_url
-    "https://www.yammer.com/api/v1/messages"
+    plugin.class::MESSAGES_API_URL
   end
 
   # fake click for the authorize step in Yammer, by hitting local webrick server


### PR DESCRIPTION
Use rest-client gem over yam (which had a very old dependency on rest-client). Also converts net/http call (during Oauth) to use RestClient.  Some refactoring of constant names too.

Version bumped for next release.