### PR TITLE
Refactor plugin config for lolcommits 0.10.0

### DIFF
--- a/lib/lolcommits/plugin/yammer.rb
+++ b/lib/lolcommits/plugin/yammer.rb
@@ -16,15 +16,6 @@ module Lolcommits
       OAUTH_REDIRECT_URL  = "http://localhost:#{OAUTH_REDIRECT_PORT}".freeze
 
       ##
-      # Returns the name of the plugin.
-      #
-      # @return [String] the plugin name
-      #
-      def self.name
-        'yammer'
-      end
-
-      ##
       # Returns position(s) of when this plugin should run during the capture
       # process. Posting to Yammer happens when a new capture is ready.
       #
@@ -35,13 +26,13 @@ module Lolcommits
       end
 
       ##
-      # Returns true if the plugin has been configured.
-      #
-      # @return [Boolean] true/false indicating if plugin has been configured.
+      # Returns true if the plugin has been configured correctly.
       # The access_token must be set.
       #
-      def configured?
-        !configuration['access_token'].nil?
+      # @return [Boolean] true/false
+      #
+      def valid_configuration?
+        !configuration[:access_token].nil?
       end
 
       ##
@@ -56,13 +47,13 @@ module Lolcommits
       #
       def configure_options!
         options = super
-        if options['enabled']
+        if options[:enabled]
           oauth_access_token = fetch_access_token
           if oauth_access_token
-            options.merge!('access_token' => oauth_access_token)
+            options.merge!(access_token: oauth_access_token)
           else
             puts "Aborting.. Plugin disabled since Yammer Oauth was denied"
-            options['enabled'] = false
+            options[:enabled] = false
           end
         end
         options
@@ -80,7 +71,7 @@ module Lolcommits
         response = RestClient.post(
           "https://www.yammer.com/api/v1/messages",
           { body: yammer_message, attachment1: File.new(runner.main_image) },
-          { 'Authorization' => "Bearer #{configuration["access_token"]}" }
+          { 'Authorization' => "Bearer #{configuration[:access_token]}" }
         )
 
         if response.code != 201

--- a/lib/lolcommits/yammer/version.rb
+++ b/lib/lolcommits/yammer/version.rb
@@ -1,5 +1,5 @@
 module Lolcommits
   module Yammer
-    VERSION = "0.0.4".freeze
+    VERSION = "0.0.5".freeze
   end
 end

--- a/lolcommits-yammer.gemspec
+++ b/lolcommits-yammer.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rest-client"
   spec.add_runtime_dependency "webrick"
 
-  spec.add_development_dependency "lolcommits", ">= 0.9.5"
+  spec.add_development_dependency "lolcommits", ">= 0.10.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "pry"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,10 +1,7 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-# necessary libs from lolcommits (allowing plugin to run)
-require 'git'
-require 'lolcommits/runner'
-require 'lolcommits/vcs_info'
-require 'lolcommits/backends/git_info'
+# lolcommits gem
+require 'lolcommits'
 
 # lolcommit test helpers
 require 'lolcommits/test_helpers/git_repo'


### PR DESCRIPTION
* require at least lolcommits >= 0.10.0
* drop`self.name` method (plugins are now identified by their gem name)
* drop calls to `configured?` (no longer available or useful)
* symbolize all plugin config keys
* bump gem version (for new plugin release)